### PR TITLE
Singola modifica al nome del parametro passato nella request, che non corrispondeva con quello specificato all'interno della jsp, causando così una NullPointerException.

### DIFF
--- a/src/main/java/controller/ShowProductServlet.java
+++ b/src/main/java/controller/ShowProductServlet.java
@@ -26,7 +26,7 @@ public class ShowProductServlet extends HttpServlet {
         PhysicalProductDAO pdao = new PhysicalProductDAO();
         Product product;
 
-        int idProdcut = Integer.parseInt(req.getParameter("idProduct"));
+        int idProdcut = Integer.parseInt(req.getParameter("productId"));
         String productType = req.getParameter("productType");
 
         if (productType.equalsIgnoreCase("digital")) {


### PR DESCRIPTION
Singola modifica al nome del parametro passato nella request, che non corrispondeva con quello specificato all'interno della shop.jsp, causando così una NullPointerException.